### PR TITLE
Make sieve recipe conditional on Ex Nihilo being loaded

### DIFF
--- a/src/main/resources/data/elementalcraft/recipes/inertcrystal_from_ens_sieve.json
+++ b/src/main/resources/data/elementalcraft/recipes/inertcrystal_from_ens_sieve.json
@@ -1,19 +1,32 @@
 {
-  "type": "exnihilosequentia:sieve",
-  "rolls": [
+  "type": "forge:conditional",
+  "recipes": [
     {
-      "chance": 0.015,
-      "mesh": "iron"
-    },
-    {
-      "chance": 0.015,
-      "mesh": "diamond"
+      "conditions": [
+        {
+          "type": "forge:mod_loaded",
+          "modid": "exnihilosequentia"
+        }
+      ],
+      "recipe": {
+        "type": "exnihilosequentia:sieve",
+        "rolls": [
+          {
+            "chance": 0.015,
+            "mesh": "iron"
+          },
+          {
+            "chance": 0.015,
+            "mesh": "diamond"
+          }
+        ],
+        "input": {
+          "item": "minecraft:gravel"
+        },
+        "result": {
+          "item": "elementalcraft:inertcrystal"
+        }
+      }
     }
-  ],
-  "input": {
-    "item": "minecraft:gravel"
-  },
-  "result": {
-    "item": "elemntalcraft:inertcrystal"
-  }
+  ]
 }


### PR DESCRIPTION
This prevents the following error when Ex Nihilo is not loaded: `[WARN] Failed to parse recipe elementalcraft:inertcrystal_from_ens_sieve[exnihilosequentia:sieve]: com.google.gson.JsonSyntaxException: Invalid or unsupported recipe type 'exnihilosequentia:sieve'`