### PR TITLE
repair and translocation spells can no longer be found in chest, they must be crafted

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
+- repair and translocation spells can no longer be found in chest, they must be crafted
 - fix source altars not generating properly
 - fix growth ratio not applying correctly to ranges
 - fix repair spell not working properly
 - fix spells using range in place of their strength
+- fix missing model for element valve in logs
 
 
 7.1.1:

--- a/src/datagen/java/sirttas/elementalcraft/datagen/managed/SpellPropertiesProvider.java
+++ b/src/datagen/java/sirttas/elementalcraft/datagen/managed/SpellPropertiesProvider.java
@@ -115,7 +115,6 @@ public class SpellPropertiesProvider extends AbstractManagedDataBuilderProvider<
 				.color(218, 184, 255)
 				.consumeAmount(500)
 				.cooldown(300)
-				.weight(2)
 				.range(100);
 		builder(Spells.FEATHER_SPIKES, Spell.Type.COMBAT, ElementType.AIR)
 				.color(180, 150, 71)
@@ -151,7 +150,6 @@ public class SpellPropertiesProvider extends AbstractManagedDataBuilderProvider<
 				.consumeAmount(100)
 				.useDuration(401)
 				.cooldown(2400)
-				.weight(2)
 				.strength(1);
 		builder(Spells.LIGHT, Spell.Type.UTILITY, ElementType.FIRE)
 				.color(242, 255, 64)

--- a/src/generated/resources/data/elementalcraft/elementalcraft/spell_properties/repair.json
+++ b/src/generated/resources/data/elementalcraft/elementalcraft/spell_properties/repair.json
@@ -5,6 +5,5 @@
   "element_type": "fire",
   "spell_type": "utility",
   "strength": 1.0,
-  "use_duration": 401,
-  "weight": 2
+  "use_duration": 401
 }

--- a/src/generated/resources/data/elementalcraft/elementalcraft/spell_properties/translocation.json
+++ b/src/generated/resources/data/elementalcraft/elementalcraft/spell_properties/translocation.json
@@ -4,6 +4,5 @@
   "element_consumption": 500,
   "element_type": "air",
   "range": 100.0,
-  "spell_type": "utility",
-  "weight": 2
+  "spell_type": "utility"
 }

--- a/src/main/java/sirttas/elementalcraft/item/spell/AbstractSpellHolderItem.java
+++ b/src/main/java/sirttas/elementalcraft/item/spell/AbstractSpellHolderItem.java
@@ -92,11 +92,11 @@ public abstract class AbstractSpellHolderItem extends Item implements ISpellHold
 
 		AttributesHelper.addAttributes(attributeMap, attributes);
 
-		InteractionResult result = Boolean.TRUE.equals(ECConfig.SERVER.spellConsumeOnFail.get()) || spell.consume(player, true) ? castSpell(player, spell) : InteractionResult.FAIL;
+		InteractionResult result = ECConfig.SERVER.spellConsumeOnFail.get() || spell.consume(player, true) ? castSpell(player, spell) : InteractionResult.FAIL;
 
 		if (result.consumesAction()) {
-			if (doConsume(player, hand, stack, spell)) {
-				result = InteractionResult.SUCCESS;
+			if (result.indicateItemUse()) {
+                doConsume(player, hand, stack, spell);
 			}
 			if (result.shouldSwing() && !player.getAbilities().instabuild) {
 				if (!level.isClientSide) {
@@ -134,14 +134,12 @@ public abstract class AbstractSpellHolderItem extends Item implements ISpellHold
 		return result;
 	}
 	
-	private boolean doConsume(Player player, InteractionHand hand, ItemStack stack, Spell spell) {
+	private void doConsume(Player player, InteractionHand hand, ItemStack stack, Spell spell) {
 		if (!player.getAbilities().instabuild && !spell.consume(player, false)) {
 			consume(stack);
 			player.onEquippedItemBroken(this, LivingEntity.getSlotForHand(hand));
-			return true;
-		}
-		return false;
-	}
+        }
+    }
 
 	protected abstract void consume(ItemStack stack);
 

--- a/src/main/java/sirttas/elementalcraft/spell/SpellHelper.java
+++ b/src/main/java/sirttas/elementalcraft/spell/SpellHelper.java
@@ -119,6 +119,7 @@ public class SpellHelper {
 	public static Holder<Spell> randomSpell(Iterable<? extends Holder<Spell>> spells, RandomSource rand) {
 		var list = StreamSupport.stream(spells.spliterator(), false)
 				.filter(SpellHelper::isValid)
+                .filter(h -> h.value().getWeight() > 0)
 				.toList();
 
 		if (list.isEmpty()) {

--- a/src/main/resources/assets/elementalcraft/models/elementalcraft/pipe_upgrades/element_valve.json
+++ b/src/main/resources/assets/elementalcraft/models/elementalcraft/pipe_upgrades/element_valve.json
@@ -1,0 +1,3 @@
+{
+	"parent": "elementalcraft:elementalcraft/pipe_upgrades/pipe_upgrade"
+}


### PR DESCRIPTION
… must be crafted